### PR TITLE
Add department-specific layouts and improve web manifest icons

### DIFF
--- a/histo/site.webmanifest
+++ b/histo/site.webmanifest
@@ -9,13 +9,30 @@
     "theme_color": "#69c9d0",
     "icons": [
         {
-            "src": "../apple-touch-icon.png",
-            "sizes": "180x180",
-            "type": "image/png"
+            "src": "../web-app-manifest-192x192.png",
+            "sizes": "192x192",
+            "type": "image/png",
+            "purpose": "maskable"
+        },
+        {
+            "src": "../web-app-manifest-512x512.png",
+            "sizes": "512x512",
+            "type": "image/png",
+            "purpose": "maskable"
+        },
+        {
+            "src": "../favicon.svg",
+            "sizes": "any",
+            "type": "image/svg+xml"
         },
         {
             "src": "../favicon-96x96.png",
             "sizes": "96x96",
+            "type": "image/png"
+        },
+        {
+            "src": "../apple-touch-icon.png",
+            "sizes": "180x180",
             "type": "image/png"
         }
     ]

--- a/index.html
+++ b/index.html
@@ -1316,6 +1316,7 @@
             loadPolicyClicks(); // Load policy click data FIRST
             await loadDefaultData();
             loadUserData();
+            checkDeptParam(); // Apply department layout for first-time users
             renderDashboard();
             renderPolicies();
             checkLayoutParam(); // Check for ?layout= URL parameter
@@ -2506,6 +2507,48 @@
         if (layoutCode) {
             setTimeout(() => applyLayoutCode(layoutCode, true), 300);
         }
+    }
+
+    // ── Department-specific default layouts ───────────────
+    // Maps dept URL param to an ordered list of link IDs for the top 8 tiles.
+    // Add new departments here — the rest of the app picks them up automatically.
+    const DEPT_LAYOUTS = {
+        histo: [13, 27, 22, 29, 1, 8, 6, 4],    // Histology Portal, Huddle Notes, Teams, QC Charts, EORLA, Omni, UKG, AP Portal
+        surgpath: [12, 28, 9, 1, 8, 6, 4, 10],   // SURGPATH, Huddle Minutes, Schedule, EORLA, Omni, UKG, AP Portal, CAP Protocols
+    };
+
+    // On first visit (no saved data), if ?dept= is set, reorder links
+    // so the department-relevant tiles appear first on the dashboard.
+    function checkDeptParam() {
+        // Only apply for first-time users (no existing personalisation)
+        if (localStorage.getItem('workspaceData')) return;
+
+        const params = new URLSearchParams(window.location.search);
+        const dept = params.get('dept');
+        if (!dept || !DEPT_LAYOUTS[dept]) return;
+
+        const priorityIds = DEPT_LAYOUTS[dept];
+
+        // Partition links into priority (in order) and the rest
+        const priority = [];
+        const rest = [];
+        for (const id of priorityIds) {
+            const link = links.find(l => l.id === id);
+            if (link) priority.push(link);
+        }
+        for (const link of links) {
+            if (!priorityIds.includes(link.id)) rest.push(link);
+        }
+
+        links = [...priority, ...rest];
+        saveUserData();
+
+        // Clean the dept param from the URL so bookmarks stay neutral
+        if (window.location.search.includes('dept=')) {
+            window.history.replaceState({}, '', window.location.pathname);
+        }
+
+        console.log('Applied department layout:', dept);
     }
 
         // Export data in data.json format (for GitHub comparison)

--- a/storage-test.html
+++ b/storage-test.html
@@ -14,7 +14,6 @@
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
-```
     body {
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
         background: linear-gradient(135deg, #69c9d0 0%, #12412f 100%);
@@ -173,7 +172,6 @@
     .badge.yellow { background: #92400e; color: #fef3c7; }
     .badge.blue { background: #1e40af; color: #dbeafe; }
 </style>
-```
 
 </head>
 <body>
@@ -183,7 +181,6 @@
             <p>Determines which storage mechanisms survive browser/Edge closure on managed PCs</p>
         </div>
 
-```
     <!-- PWA mode indicator -->
     <div class="card" style="padding: 16px;">
         <div id="modeIndicator" class="status checking">
@@ -623,7 +620,6 @@
 
     checkAll();
 </script>
-```
 
 </body>
 </html>

--- a/surgpath/site.webmanifest
+++ b/surgpath/site.webmanifest
@@ -9,13 +9,30 @@
     "theme_color": "#69c9d0",
     "icons": [
         {
-            "src": "../apple-touch-icon.png",
-            "sizes": "180x180",
-            "type": "image/png"
+            "src": "../web-app-manifest-192x192.png",
+            "sizes": "192x192",
+            "type": "image/png",
+            "purpose": "maskable"
+        },
+        {
+            "src": "../web-app-manifest-512x512.png",
+            "sizes": "512x512",
+            "type": "image/png",
+            "purpose": "maskable"
+        },
+        {
+            "src": "../favicon.svg",
+            "sizes": "any",
+            "type": "image/svg+xml"
         },
         {
             "src": "../favicon-96x96.png",
             "sizes": "96x96",
+            "type": "image/png"
+        },
+        {
+            "src": "../apple-touch-icon.png",
+            "sizes": "180x180",
             "type": "image/png"
         }
     ]


### PR DESCRIPTION
## Summary
This PR adds department-specific dashboard layouts for first-time users and improves the web app manifest configuration with better icon support.

## Key Changes

- **Department-specific layouts**: Added `checkDeptParam()` function that applies pre-configured link orderings based on a `?dept=` URL parameter for first-time users
  - Histology department layout: prioritizes Histology Portal, Huddle Notes, Teams, QC Charts, and other relevant tools
  - Surgical Pathology department layout: prioritizes SURGPATH, Huddle Minutes, Schedule, and related resources
  - Only applies to users without existing saved data (first-time visitors)
  - Automatically cleans the `dept=` parameter from the URL after applying the layout

- **Web manifest icon improvements**: Updated `site.webmanifest` files in both `histo/` and `surgpath/` directories
  - Added maskable icon support (192x192 and 512x512 PNG formats)
  - Added SVG favicon for better scalability
  - Reordered icons for better PWA compatibility
  - Maintains backward compatibility with existing favicon formats

- **Bug fix**: Removed stray markdown code fence markers from `storage-test.html`

## Implementation Details

The `checkDeptParam()` function:
- Checks for existing user data before applying changes (respects user preferences)
- Uses a `DEPT_LAYOUTS` configuration object for easy addition of new departments
- Partitions links into priority (department-specific) and remaining links
- Saves the reordered layout to localStorage
- Cleans the URL to keep bookmarks neutral and prevent repeated application

The web manifest updates follow PWA best practices by including maskable icons for adaptive icon display on modern devices.

https://claude.ai/code/session_01Wg8PGM6hgi4hTbB29jUSSy